### PR TITLE
Add SSL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+## [0.1.0] - 2015-08-27
+### Added
+- SSL support
+
 ## [0.0.3] - 2015-07-14
 ### Changed
 - updated sensu-plugin gem to 1.2.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@
 
 ## Usage
 
+    Usage: check-etcd.rb (options)
+           --ca CA                      SSL CA file
+           --cert CERT                  client SSL cert
+           --insecure                   change SSL verify mode to false
+           --key KEY                    client SSL key
+           --passphrase PASSPHRASE      passphrase of the SSL key
+       -p, --port PORT                  Etcd port, defaults to 2379
+       -h, --host HOST                  Etcd host, defaults to localhost
+           --ssl                        use HTTPS (default false)
+
 ## Installation
 
 [Installation and Setup](https://github.com/sensu-plugins/documentation/blob/master/user_docs/installation_instructions.md)

--- a/bin/check-etcd.rb
+++ b/bin/check-etcd.rb
@@ -28,6 +28,7 @@
 
 require 'sensu-plugin/check/cli'
 require 'rest-client'
+require 'openssl'
 
 #
 # Etcd Node Status
@@ -45,8 +46,44 @@ class EtcdNodeStatus < Sensu::Plugin::Check::CLI
          long: '--port PORT',
          default: '2379'
 
+  option :cert,
+         description: 'client SSL cert',
+         long: '--cert CERT',
+         default: nil
+
+  option :key,
+         description: 'client SSL key',
+         long: '--key KEY',
+         default: nil
+
+  option :passphrase,
+         description: 'passphrase of the SSL key',
+         long: '--passphrase PASSPHRASE',
+         default: nil
+
+  option :ca,
+         description: 'SSL CA file',
+         long: '--ca CA',
+         default: nil
+
+  option :insecure,
+         description: 'change SSL verify mode to false',
+         long: '--insecure'
+
+  option :ssl,
+         description: 'use HTTPS (default false)',
+         long: '--ssl'
+
   def run
-    r = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}/v2/stats/self", timeout: 5).get
+    protocol = config[:ssl] ? 'https' : 'http'
+
+    r = RestClient::Resource.new("#{protocol}://#{config[:server]}:#{config[:port]}/v2/stats/self",
+                                 timeout: 5,
+                                 :ssl_client_cert  => (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
+                                 :ssl_client_key   => (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
+                                 :ssl_ca_file      =>  config[:ca],
+                                 :verify_ssl       =>  config[:insecure] ? 0 : 1
+                                ).get
     if r.code == 200
       ok 'etcd is up'
     else

--- a/bin/check-etcd.rb
+++ b/bin/check-etcd.rb
@@ -79,10 +79,10 @@ class EtcdNodeStatus < Sensu::Plugin::Check::CLI
 
     r = RestClient::Resource.new("#{protocol}://#{config[:server]}:#{config[:port]}/v2/stats/self",
                                  timeout: 5,
-                                 :ssl_client_cert  => (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
-                                 :ssl_client_key   => (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
-                                 :ssl_ca_file      =>  config[:ca],
-                                 :verify_ssl       =>  config[:insecure] ? 0 : 1
+                                 ssl_client_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
+                                 ssl_client_key: (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
+                                 ssl_ca_file:  config[:ca],
+                                 verify_ssl:  config[:insecure] ? 0 : 1
                                 ).get
     if r.code == 200
       ok 'etcd is up'

--- a/lib/sensu-plugins-etcd/version.rb
+++ b/lib/sensu-plugins-etcd/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsEtcd
   module Version
     MAJOR = 0
-    MINOR = 0
-    PATCH = 3
+    MINOR = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
We are using this plugin to check etcd shipped in Openshift. Problem is etcd in openshift uses SSL and SSL client-side cert. Moreover, CA file in openshift has a generic CN, so we need to be able to set verify_ssl to false.

This commit adds options to support SSL in a backwards-compatible manner.
