### PR TITLE
etcd check: use the /health endpoint

### DIFF
--- a/bin/check-etcd.rb
+++ b/bin/check-etcd.rb
@@ -77,17 +77,17 @@ class EtcdNodeStatus < Sensu::Plugin::Check::CLI
   def run
     protocol = config[:ssl] ? 'https' : 'http'
 
-    r = RestClient::Resource.new("#{protocol}://#{config[:server]}:#{config[:port]}/v2/stats/self",
+    r = RestClient::Resource.new("#{protocol}://#{config[:server]}:#{config[:port]}/health",
                                  timeout: 5,
                                  ssl_client_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
                                  ssl_client_key: (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
                                  ssl_ca_file:  config[:ca],
                                  verify_ssl:  config[:insecure] ? 0 : 1
                                 ).get
-    if r.code == 200
-      ok 'etcd is up'
+    if r.code == 200 && JSON.parse(r.to_str)['health'] == 'true'
+      ok 'Etcd healthy'
     else
-      critical 'Etcd is not responding'
+      critical 'Etcd unhealthy'
     end
   rescue Errno::ECONNREFUSED
     critical 'Etcd is not responding'

--- a/lib/sensu-plugins-etcd/version.rb
+++ b/lib/sensu-plugins-etcd/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsEtcd
   module Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
it's better to verify the health of a node by checking the endpoint /health :
- etcd can respond 200 on /v2/stats/self even if all cluster is unhealthy
- 200 on /v2/stats/self does not mean the node is healthy
