### PR TITLE
Add allmember option to check-etc.rb; Add etcd peer count check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Added full cluster health check option for check-etcd
+- Added healthy peer count check
 
 ## [0.1.0] - 2015-08-27
 ### Added

--- a/bin/check-etcd-peer-count.rb
+++ b/bin/check-etcd-peer-count.rb
@@ -1,0 +1,106 @@
+#! /usr/bin/env ruby
+#
+#   check-etcd-peer-count
+#
+# DESCRIPTION:
+#   This plugin checks that the number of etcd members reporting is correct
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# USAGE:
+#   #YELLOW
+#
+# NOTES:
+#
+# LICENSE:
+#   Barry Martin <nyxcharon@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'rest-client'
+require 'openssl'
+
+#
+# Etcd Node Status
+#
+class EtcdNodeStatus < Sensu::Plugin::Check::CLI
+  option :server,
+         description: 'Etcd host, defaults to localhost',
+         short: '-h HOST',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :port,
+         description: 'Etcd port, defaults to 2379',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: '2379'
+
+  option :cert,
+         description: 'client SSL cert',
+         long: '--cert CERT',
+         default: nil
+
+  option :key,
+         description: 'client SSL key',
+         long: '--key KEY',
+         default: nil
+
+  option :passphrase,
+         description: 'passphrase of the SSL key',
+         long: '--passphrase PASSPHRASE',
+         default: nil
+
+  option :ca,
+         description: 'SSL CA file',
+         long: '--ca CA',
+         default: nil
+
+  option :insecure,
+         description: 'change SSL verify mode to false',
+         long: '--insecure'
+
+  option :ssl,
+         description: 'use HTTPS (default false)',
+         long: '--ssl'
+
+  option :peercount,
+         description: 'Number of expected etcd peers',
+         short: '-c NUMBER',
+         long: '--count NUMBER',
+         required: true,
+         proc: proc(&:to_i)
+
+  def run
+    protocol = config[:ssl] ? 'https' : 'http'
+    r = RestClient::Resource.new("#{protocol}://#{config[:server]}:#{config[:port]}/v2/members",
+                                 timeout: 5,
+                                 ssl_client_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
+                                 ssl_client_key: (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
+                                 ssl_ca_file:  config[:ca],
+                                 verify_ssl:  config[:insecure] ? 0 : 1
+                                ).get
+    peers = JSON.parse(r.to_str)['members'].length
+    if r.code == 200 && peers == config[:peercount]
+      ok 'Etcd has correct number of peers'
+    else
+      critical "Etcd peer count incorrect, expected #{config[:peercount]} got #{peers}"
+    end
+  rescue Errno::ECONNREFUSED
+    critical 'Etcd is not responding'
+  rescue RestClient::RequestTimeout
+    critical 'Etcd Connection timed out'
+  rescue StandardError => e
+    unknown 'A exception occurred: ' + e.message
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No
#### General
- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [X] RuboCop passes
- [ ] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose
- Added a check to verify the expected number of healthy etcd peers is what you expect
- Added a option to check-etcd to have it check every member in the cluster. Currently the check will only check one member. This option pulls the list of peers via the api, then runs the health check on each one. The flag was added in a way so as to not break the original functionality. 
#### Known Compatablity Issues

None.
