### PR TITLE
Add rescue block for connection problems

### DIFF
--- a/bin/check-etcd.rb
+++ b/bin/check-etcd.rb
@@ -87,8 +87,12 @@ class EtcdNodeStatus < Sensu::Plugin::Check::CLI
       bad_peers = []
       members.each do |member|
         client_host = URI.parse(member['clientURLs'][0]).host
-        r = request('/health', client_host)
-        unless r.code == 200 && JSON.parse(r.to_str)['health'] == 'true'
+        begin
+          r = request('/health', client_host)
+          unless r.code == 200 && JSON.parse(r.to_str)['health'] == 'true'
+            bad_peers += [client_host]
+          end
+        rescue StandardError
           bad_peers += [client_host]
         end
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Nope
#### General
- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [X] RuboCop passes
- [ ] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

This is an amendment to my previous PR(#5). In the case of network errors or a etcd node not responding to a request, this catches that node and reports on it's error. Before this change all network errors like this got swallowed resulting in unknown status. This change makes it much easier to identify problems nodes.
#### Known Compatablity Issues

None.
