### PR TITLE
Remove Ruby 1.9 support, change minimum Ruby from 2.1 to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:
@@ -30,4 +30,5 @@ deploy:
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
     repo: sensu-plugins/sensu-plugins-etcd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- Removed Ruby 1.9 support
+### Added
 - Added full cluster health check option for check-etcd
 - Added healthy peer count check
 - Adding flanneld subnet check for etcd

--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,6 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
-
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
@@ -44,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: args
+task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]

--- a/sensu-plugins-etcd.gemspec
+++ b/sensu-plugins-etcd.gemspec
@@ -2,14 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-etcd'
-else
-  require_relative 'lib/sensu-plugins-etcd'
-end
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
+require_relative 'lib/sensu-plugins-etcd'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
@@ -30,7 +23,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.1.0'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for etcd'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist

Relates to Sensu Plugins Ruby 1.9 deprecation policy and cc09664744526abc18c7da4a5471489229e646a4
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

Complete changes made in cc09664744526abc18c7da4a5471489229e646a4 to update this gem for removing Ruby 1.9 support.
#### Known Compatibility Issues

Introduces compatibility with Ruby 1.9
