### PR TITLE
Do not assume type of private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
 - Updated Travis configuration to include Ruby 2.4.1
+- Updated to be compatible with other type of private keys than RSA
 
 ### Removed
 - Ruby 1.9.3 from deploy-time testing (@eheydrick)

--- a/bin/check-etcd-peer-count.rb
+++ b/bin/check-etcd-peer-count.rb
@@ -87,7 +87,7 @@ class EtcdNodeStatus < Sensu::Plugin::Check::CLI
     r = RestClient::Resource.new("#{protocol}://#{config[:server]}:#{config[:port]}/v2/members",
                                  timeout: 5,
                                  ssl_client_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
-                                 ssl_client_key: (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
+                                 ssl_client_key: (OpenSSL::PKey.read(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
                                  ssl_ca_file:  config[:ca],
                                  verify_ssl:  config[:insecure] ? 0 : 1).get
     peers = JSON.parse(r.to_str)['members'].length

--- a/bin/check-etcd.rb
+++ b/bin/check-etcd.rb
@@ -124,7 +124,7 @@ class EtcdNodeStatus < Sensu::Plugin::Check::CLI
     RestClient::Resource.new("#{protocol}://#{server}:#{config[:port]}/#{path}",
                              timeout: 5,
                              ssl_client_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
-                             ssl_client_key: (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
+                             ssl_client_key: (OpenSSL::PKey.read(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
                              ssl_ca_file:  config[:ca],
                              verify_ssl:  config[:insecure] ? 0 : 1).get
   end

--- a/bin/check-flannel-subnet-count.rb
+++ b/bin/check-flannel-subnet-count.rb
@@ -122,7 +122,7 @@ class FlannelSubnetStatus < Sensu::Plugin::Check::CLI
       "#{protocol}://#{server}:#{config[:port]}/#{path}",
       timeout: 5,
       ssl_client_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
-      ssl_client_key: (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
+      ssl_client_key: (OpenSSL::PKey.read(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
       ssl_ca_file:  config[:ca],
       verify_ssl:  config[:insecure] ? 0 : 1
     ).get

--- a/bin/metrics-etcd.rb
+++ b/bin/metrics-etcd.rb
@@ -96,7 +96,7 @@ class EtcdMetrics < Sensu::Plugin::Metric::CLI::Graphite
         verify_mode: (config[:insecure] ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER),
         ca_file: config[:ca],
         ssl_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
-        ssl_key:  (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?)
+        ssl_key:  (OpenSSL::PKey.read(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?)
       )
     else
       client = Etcd.client(host: config[:etcd_host], port: config[:etcd_port])


### PR DESCRIPTION
The only type of private key supported at the moment are RSA keys.
Since there are multiple types (RSA, DSA, EC ...), it would be best
not to assume.

Seems like the OpenSSL::PKey.read(string [,pwd]) does exactly what
we need to have that abstraction:

  Reads a DER or PEM encoded string from string or io and returns an
  instance of the appropriate PKey class.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass (no tests)

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

